### PR TITLE
Switch to AWS Comprehend for texts' sentiment analysis. Closes #4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,11 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -92,6 +97,12 @@
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.3.tgz",
       "integrity": "sha512-LTwJcUGRzjQCR6uQCXMEUkoecezmWNjyWRjPm9pv0WlIYtLLaOnVsR1RvAdSMgOJPTFNlxS1IkfXxrkmV+gcyQ=="
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -130,6 +141,15 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
@@ -361,6 +381,12 @@
         "preserve": "^0.2.0",
         "repeat-element": "^1.1.2"
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
@@ -640,6 +666,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -745,6 +780,36 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -754,6 +819,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "etag": {
@@ -939,6 +1010,15 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
       }
     },
     "follow-redirects": {
@@ -1547,6 +1627,12 @@
         }
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1607,10 +1693,31 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "has-value": {
@@ -1678,6 +1785,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.5",
@@ -1762,6 +1875,18 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -1770,6 +1895,12 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -1870,6 +2001,24 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -1880,6 +2029,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -1894,6 +2049,16 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -1944,8 +2109,16 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
     },
     "loglevel": {
       "version": "1.6.6",
@@ -2073,6 +2246,204 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.0.tgz",
+      "integrity": "sha512-MymHK8UkU0K15Q/zX7uflZgVoRWiTjy0fXE/QjKts6mowUvGxOdPhZ2qj3b0iZdUrNZlW9LAIMFHB4IW+2b3EQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2141,6 +2512,16 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2184,6 +2565,18 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -2199,6 +2592,28 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.omit": {
@@ -2324,6 +2739,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -3196,6 +3617,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -3233,6 +3660,26 @@
         "strip-ansi": "^5.1.0"
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -3241,6 +3688,12 @@
       "requires": {
         "ansi-regex": "^4.1.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "subarg": {
       "version": "1.0.0",
@@ -3478,11 +3931,56 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -3547,6 +4045,17 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       }
     },
     "yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,51 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/aws-lambda": {
       "version": "8.10.40",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.40.tgz",
@@ -18,6 +63,21 @@
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/chai": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.10.tgz",
+      "integrity": "sha512-TlWWgb21+0LdkuFqEqfmy7NEgfB/7Jjux15fWQAh3P93gbmXuwTM/vxEdzW89APIcI2BgKR48yjeAkdeH+4qvQ==",
+      "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
       }
     },
     "@types/connect": {
@@ -53,12 +113,19 @@
     "@types/lodash": {
       "version": "4.14.149",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true
     },
     "@types/node": {
@@ -82,6 +149,12 @@
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -181,6 +254,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -440,6 +519,29 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -461,6 +563,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -665,6 +773,15 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1639,6 +1756,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -2079,6 +2202,12 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -2110,6 +2239,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -2512,6 +2647,36 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -2739,6 +2904,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.1",
@@ -3406,6 +3577,38 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
+    "sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -3796,6 +3999,12 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,20 @@
     "typescript": "^3.7.5"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.149",
     "@types/aws-lambda": "^8.10.40",
+    "@types/chai": "^4.2.10",
+    "@types/chai-as-promised": "^7.1.2",
     "@types/express": "^4.17.2",
+    "@types/lodash": "^4.14.149",
+    "@types/mocha": "^7.0.2",
+    "@types/sinon": "^7.5.2",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "concurrently": "^5.1.0",
     "cpx": "^1.5.0",
     "mocha": "^7.1.0",
     "rimraf": "^3.0.2",
+    "sinon": "^9.0.0",
     "ts-node": "^8.6.2"
   },
   "scripts": {
@@ -29,9 +36,9 @@
     "build": "tsc && npm run copy-dependencies",
     "build-watch": "npm run build && cpx ./.env ./dist && tsc -w --preserveWatchOutput true",
     "copy-dependencies": "cpx ./package.json ./dist && cpx ./package-lock.json ./dist && cd ./dist && npm i --production",
-    "start": "concurrently --kill-others --kill-others-on-fail \"npm run build-watch\" \"sam local start-api -p 3001 --template ./template.yaml\"",
-    "scrape": "npm run prestart && ts-node -r dotenv/config calculate-neutrality.ts",
-    "test": "mocha --require ts-node/register ./**/*.spec.ts",
+    "start": "concurrently --kill-others --kill-others-on-fail \"npm run build-watch\" \"docker pull lambci/lambda:nodejs12.x && sam local start-api -p 3001 --skip-pull-image --template ./template.yaml\"",
+    "scrape": "npm run prestart && ts-node -r dotenv/config ./src/calculate-neutrality.ts",
+    "test": "mocha --require ts-node/register ./src/**/*.spec.ts",
     "prestart": "ts-node -r dotenv/config src/init.ts",
     "start-api": "ts-node -r dotenv/config src/api.ts"
   },

--- a/package.json
+++ b/package.json
@@ -8,16 +8,19 @@
     "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "lodash": "^4.17.15",
     "loglevel": "^1.6.6",
     "natural": "^0.6.3",
     "rxjs": "^6.5.4",
     "typescript": "^3.7.5"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.149",
     "@types/aws-lambda": "^8.10.40",
     "@types/express": "^4.17.2",
     "concurrently": "^5.1.0",
     "cpx": "^1.5.0",
+    "mocha": "^7.1.0",
     "rimraf": "^3.0.2",
     "ts-node": "^8.6.2"
   },
@@ -28,7 +31,7 @@
     "copy-dependencies": "cpx ./package.json ./dist && cpx ./package-lock.json ./dist && cd ./dist && npm i --production",
     "start": "concurrently --kill-others --kill-others-on-fail \"npm run build-watch\" \"sam local start-api -p 3001 --template ./template.yaml\"",
     "scrape": "npm run prestart && ts-node -r dotenv/config calculate-neutrality.ts",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha --require ts-node/register ./**/*.spec.ts",
     "prestart": "ts-node -r dotenv/config src/init.ts",
     "start-api": "ts-node -r dotenv/config src/api.ts"
   },

--- a/src/calculate-neutrality.spec.ts
+++ b/src/calculate-neutrality.spec.ts
@@ -1,0 +1,51 @@
+
+import './utils/setupTest';
+import * as calculateNeutrality from './calculate-neutrality';
+import * as loadNewsServicesToAnalyze from './utils/loadNewsServicesToAnalyze';
+import sinon from 'sinon';
+import { NewsService, News } from './services/news';
+import { Observable } from 'rxjs';
+import sentimentAnalyzerService from './services/sentiment-analyzer.service';
+import { NewsSourceRepository, NewsSourceScore } from './repositories/news-sources.repository';
+import { expect } from 'chai';
+
+describe('calculate-neutrality', () => {
+  beforeEach(() => {
+    sinon.restore();
+  });
+
+  it('should retrieve scores from news services correctly', async () => {
+    const expectedScore = 0;
+    const stubNewsService: NewsService = {
+      getNewsObservable: () => new Observable(subscriber => {
+        subscriber.next({
+          title: 'test1',
+          content: 'testcontent',
+        });
+        subscriber.complete();
+      }),
+      sourceId: 'stubId',
+      sourceUrl: 'stub.com',
+      sourceCountry: 'en',
+      sourceProvider: 'stubz',
+      sourceName: 'Stubby McStub',
+    };
+    sinon.stub(loadNewsServicesToAnalyze, 'default').callsFake(() => {
+      return new Observable<NewsService>(subscriber => {
+        subscriber.next(stubNewsService);
+        subscriber.complete();
+      });
+    });
+    sinon.stub(sentimentAnalyzerService, 'analyzeText').callsFake(async (text) => expectedScore);
+    const putStub = sinon.stub(NewsSourceRepository, 'put');
+    await calculateNeutrality.calculateNeutrality();
+    sinon.assert.calledOnceWithExactly(putStub, sinon.match({
+      id: stubNewsService.sourceId,
+      url: stubNewsService.sourceUrl,
+      score: expectedScore,
+      retrievedFrom: stubNewsService.sourceProvider,
+      name: stubNewsService.sourceName,
+      country: stubNewsService.sourceCountry,
+    }).and(sinon.match.has('lastUpdatedMs', sinon.match.number)));
+  });
+});

--- a/src/calculate-neutrality.ts
+++ b/src/calculate-neutrality.ts
@@ -34,7 +34,7 @@ async function retrieveScoreFromNewsService(newsService: NewsService): Promise<n
   return avgScore;
 }
 
-async function calculateNeutrality() {
+export async function calculateNeutrality() {
   logger.info(config.newsApi);
   // get timestamp
   const timeStampMs = Date.now();
@@ -58,7 +58,7 @@ async function calculateNeutrality() {
         id: newsService.sourceId,
         url: newsService.sourceUrl,
         score: score,
-        retrievedFrom: 'https://newsapi.org',
+        retrievedFrom: newsService.sourceProvider,
         name: newsService.sourceName,
         country: newsService.sourceCountry,
         lastUpdatedMs: timeStampMs,

--- a/src/calculate-neutrality.ts
+++ b/src/calculate-neutrality.ts
@@ -1,4 +1,4 @@
-import { analyzeText } from "./services/sentiment-analyzer.service";
+import sentimentAnalyzerService from "./services/sentiment-analyzer.service";
 import { News, NewsService } from "./services/news";
 import { logger } from './utils/logger.util';
 import { craftNewsServiceFromNewsApiSource, NewsApiService, NewsApiSource } from "./services/news/newsapi.service";
@@ -37,7 +37,7 @@ async function retrieveScoreFromNewsService(newsService: NewsService): Promise<n
   let counter = 0;
   await newsService.getNewsObservable().pipe(
     map(async (news: News): Promise<number | undefined> => {
-      return analyzeText(news.content).catch(e => {
+      return sentimentAnalyzerService.analyzeText(news.content).catch(e => {
         logger.error(`Unable to retrieve score for ${newsService.sourceId}:`, e);
         return undefined;
       });

--- a/src/clients/comprehend.client.ts
+++ b/src/clients/comprehend.client.ts
@@ -1,0 +1,5 @@
+import aws from 'aws-sdk';
+
+const comprehend: aws.Comprehend = new aws.Comprehend();
+
+export default comprehend;

--- a/src/helpers/lambda.helper.ts
+++ b/src/helpers/lambda.helper.ts
@@ -39,3 +39,20 @@ export function injectCors(func: APIGatewayProxyHandler): APIGatewayProxyHandler
     }
   }
 }
+
+export function defaultApiResponseHandler(func: Function, statusCode?: number): APIGatewayProxyHandler {
+  return handleError(injectCors(async (...args) => {
+    const result = await func();
+    if (!result) {
+      return {
+        body: '',
+        statusCode: statusCode || 204,
+      }
+    } else {
+      return {
+        body: JSON.stringify(result),
+        statusCode: statusCode || 200,
+      }
+    }
+  }));
+}

--- a/src/services/news/index.ts
+++ b/src/services/news/index.ts
@@ -1,8 +1,8 @@
 import { Observable } from 'rxjs';
 
+
 export interface News {
-  title?: string;
-  subtitle?: string;
+  title: string;
   content: string;
 }
 

--- a/src/services/news/newsapi.service.ts
+++ b/src/services/news/newsapi.service.ts
@@ -1,9 +1,9 @@
-import axios, { AxiosResponse } from 'axios';
-import { config } from '../config';
-import { NewsApiError } from '../errors';
-import { News, NewsService } from './news.service';
+import axios from 'axios';
+import { config } from '../../config';
+import { NewsApiError } from '../../errors';
+import { News, NewsService } from '.';
 import { Observable, throwError } from 'rxjs';
-import { logger } from '../utils/logger.util';
+import { logger } from '../../utils/logger.util';
 
 export interface NewsApiResponse {
   status: string;

--- a/src/services/sentiment-analyzer.service.spec.ts
+++ b/src/services/sentiment-analyzer.service.spec.ts
@@ -1,0 +1,98 @@
+import { analyzeText } from "./sentiment-analyzer.service";
+import { expect } from 'chai';
+import aws from 'aws-sdk';
+import comprehend from '../clients/comprehend.client'
+import sinon from 'sinon';
+import { BatchDetectSentimentResponse, BatchDetectSentimentItemResult, ListOfDetectSentimentResult, BatchDetectSentimentRequest } from "aws-sdk/clients/comprehend";
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import mockAsync from "../utils/mockAsync";
+
+chai.use(chaiAsPromised);
+
+type AWSBatchDetectSentimentRequest = aws.Request<aws.Comprehend.BatchDetectSentimentResponse, aws.AWSError>;
+
+function generateResultList(texts: Array<string>): ListOfDetectSentimentResult {
+  return texts.map<BatchDetectSentimentItemResult>((e, index) => {
+    return {
+      Index: index,
+      SentimentScore: {
+        // keep in mind we don't validate what comprehend returns here, so it's all g if we be a bit wack
+        Positive: e.length,
+        Negative: 0,
+      }
+    }
+  });
+}
+
+function generateTextList(desiredLength: number): Array<string> {
+  const output: Array<string> = [];
+  for (let i = 0; i < desiredLength; i++) {
+    output.push('1'.padStart(i + 1, '1'));
+  }
+  return output;
+}
+
+describe("sentiment-analyzer.service", () => {
+  beforeEach(() => {
+    sinon.restore();
+  });
+
+  it('should analyse text successfully', async () => {
+    const input = 'I hate this project.';
+    sinon.stub(comprehend, 'batchDetectSentiment').returns({
+      promise: () => Promise.resolve<BatchDetectSentimentResponse>({
+        ResultList: [
+          {
+            Index: 0,
+            SentimentScore: {
+              Negative: 0.60,
+              Positive: 0.40,
+              Neutral: 0,
+            }
+          }
+        ],
+        ErrorList: [],
+      })
+    } as AWSBatchDetectSentimentRequest);
+    const score = await analyzeText(input);
+    expect(score).to.not.be.undefined;
+    expect(score).to.equal(0.4 - 0.6);
+  });
+
+  it('should throw appropriate errors when resultlist indexes are messed up', async () => {
+    const input = 'I hate this project.';
+    sinon.stub(comprehend, 'batchDetectSentiment').returns({
+      promise: () => Promise.resolve<BatchDetectSentimentResponse>({
+        ResultList: [
+          {
+            Index: 12314124123,
+            SentimentScore: {
+              Negative: 0.60,
+              Positive: 0.40,
+              Neutral: 0,
+            }
+          }
+        ],
+        ErrorList: [],
+      })
+    } as AWSBatchDetectSentimentRequest);
+    expect(analyzeText(input)).to.eventually.be.rejected;
+  });
+
+  it('should be able to handle large volumes of texts (25+)', async () => {
+    const inputs = generateTextList(1001);
+    sinon.stub(comprehend, 'batchDetectSentiment').callsFake(((params: BatchDetectSentimentRequest) => {
+      return {
+        promise: () => mockAsync<BatchDetectSentimentResponse>({
+          ResultList: generateResultList(params.TextList),
+          ErrorList: [],
+        }, 1000)
+      } as AWSBatchDetectSentimentRequest;
+    }) as any);
+    await Promise.all(inputs.map(async input => {
+      const score = await analyzeText(input);
+      expect(score).to.equal(input.length);
+    }));
+  }).timeout(60000);
+});

--- a/src/services/sentiment-analyzer.service.spec.ts
+++ b/src/services/sentiment-analyzer.service.spec.ts
@@ -1,4 +1,4 @@
-import { analyzeText } from "./sentiment-analyzer.service";
+import sentimentAnalyzerService from "./sentiment-analyzer.service";
 import { expect } from 'chai';
 import aws from 'aws-sdk';
 import comprehend from '../clients/comprehend.client'
@@ -55,7 +55,7 @@ describe("sentiment-analyzer.service", () => {
         ErrorList: [],
       })
     } as AWSBatchDetectSentimentRequest);
-    const score = await analyzeText(input);
+    const score = await sentimentAnalyzerService.analyzeText(input);
     expect(score).to.not.be.undefined;
     expect(score).to.equal(0.4 - 0.6);
   });
@@ -77,7 +77,7 @@ describe("sentiment-analyzer.service", () => {
         ErrorList: [],
       })
     } as AWSBatchDetectSentimentRequest);
-    expect(analyzeText(input)).to.eventually.be.rejected;
+    expect(sentimentAnalyzerService.analyzeText(input)).to.eventually.be.rejected;
   });
 
   it('should be able to handle large volumes of texts (25+)', async () => {
@@ -91,7 +91,7 @@ describe("sentiment-analyzer.service", () => {
       } as AWSBatchDetectSentimentRequest;
     }) as any);
     await Promise.all(inputs.map(async input => {
-      const score = await analyzeText(input);
+      const score = await sentimentAnalyzerService.analyzeText(input);
       expect(score).to.equal(input.length);
     }));
   }).timeout(60000);

--- a/src/services/sentiment-analyzer.service.spec.ts
+++ b/src/services/sentiment-analyzer.service.spec.ts
@@ -4,11 +4,8 @@ import aws from 'aws-sdk';
 import comprehend from '../clients/comprehend.client'
 import sinon from 'sinon';
 import { BatchDetectSentimentResponse, BatchDetectSentimentItemResult, ListOfDetectSentimentResult, BatchDetectSentimentRequest } from "aws-sdk/clients/comprehend";
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import mockAsync from "../utils/mockAsync";
-
-chai.use(chaiAsPromised);
+import '../utils/setupTest';
 
 type AWSBatchDetectSentimentRequest = aws.Request<aws.Comprehend.BatchDetectSentimentResponse, aws.AWSError>;
 
@@ -77,7 +74,7 @@ describe("sentiment-analyzer.service", () => {
         ErrorList: [],
       })
     } as AWSBatchDetectSentimentRequest);
-    expect(sentimentAnalyzerService.analyzeText(input)).to.eventually.be.rejected;
+    await expect(sentimentAnalyzerService.analyzeText(input)).to.eventually.be.rejected;
   });
 
   it('should be able to handle large volumes of texts (25+)', async () => {

--- a/src/services/sentiment-analyzer.service.ts
+++ b/src/services/sentiment-analyzer.service.ts
@@ -73,9 +73,9 @@ async function dispatch() {
       docRequest.onError(e);
     });
   } catch (e) {
+    // it's a bad batch homie! let's get rid of em all
     logger.error(e);
     requestList.forEach(request => request.onError(e));
-    throw e;
   }
 }
 

--- a/src/services/sentiment-analyzer.service.ts
+++ b/src/services/sentiment-analyzer.service.ts
@@ -1,15 +1,100 @@
-import * as natural from 'natural';
+import comprehend from '../clients/comprehend.client';
+import _ from 'lodash';
+import { logger } from '../utils/logger.util';
+import { BatchDetectSentimentItemResult } from 'aws-sdk/clients/comprehend';
+
+interface SentimentRequest {
+  text: string;
+  onDone: (result: number) => any;
+  onError: (e: any) => any;
+}
+
+let batchBuffer: Array<SentimentRequest> = [];
+let timeoutToken: ReturnType<typeof setTimeout> | undefined = undefined;
+const WAIT_MS_BEFORE_SENDING = 1000;
+const MAX_BATCH_BUFFER_SIZE = 25;
+const COMPREHEND_QUOTA_PER_SECOND = 10;
 
 export async function analyzeText(text: string): Promise<number> {
-  if (!text) {
-    throw new Error('Unable to analyse null-texts!');
-  }
-  let tokenizedText: Array<string> = await tokenizeText(text);
-  let analyzer = new natural.SentimentAnalyzer('English', null, 'afinn');
-  return analyzer.getSentiment(tokenizedText);
+  // logger.debug('Analysing text');
+  return new Promise((res, rej) => {
+    sendForProcessing({
+      text: text,
+      onDone: e => res(e),
+      onError: err => rej(err),
+    });
+  });
 }
 
-async function tokenizeText(text: string): Promise<Array<string>> {
-  let tokenizer = new natural.WordTokenizer();
-  return tokenizer.tokenize(text);
+function clearTimeoutToken() {
+  if (timeoutToken) {
+    clearTimeout(timeoutToken);
+    timeoutToken = undefined;
+  }
 }
+
+async function dispatch() {
+  clearTimeoutToken();
+  let requestList = batchBuffer.slice(0, MAX_BATCH_BUFFER_SIZE);
+  batchBuffer = batchBuffer.slice(MAX_BATCH_BUFFER_SIZE);
+  function getRequestFromRequestList(index?: number): SentimentRequest {
+    if (index === undefined) {
+      throw new Error('wtf comprehend is this janky indexing');
+    }
+    let docRequest = requestList[index];
+    if (!docRequest) {
+      throw new Error('missing docRequest!');
+    }
+    return docRequest;
+  }
+  if (batchBuffer.length) {
+    clearTimeoutToken();
+    timeoutToken = setTimeout(() => dispatch(), 1000 / COMPREHEND_QUOTA_PER_SECOND);
+  }
+  if (!requestList.length) {
+    logger.debug('Empty requestList. Skipping!');
+    return;
+  }
+  try {
+    const result = await comprehend.batchDetectSentiment({
+      LanguageCode: 'en',
+      TextList: requestList.map(e => e.text),
+    }).promise();
+    result.ResultList.forEach((e) => {
+      let docRequest = getRequestFromRequestList(e.Index);
+      let score = computeScore(e);
+      if (!score) {
+        throw new Error(`Unable to retrieve score from AWS Comprehend: ${JSON.stringify(result)}`);
+      }
+      docRequest.onDone(score);
+    });
+    result.ErrorList.forEach(e => {
+      let docRequest = getRequestFromRequestList(e.Index);
+      docRequest.onError(e);
+    });
+  } catch (e) {
+    logger.error(e);
+    requestList.forEach(request => request.onError(e));
+    throw e;
+  }
+}
+
+function computeScore(result: BatchDetectSentimentItemResult): number {
+  const positive = _.get(result, 'SentimentScore.Positive');
+  const negative = _.get(result, 'SentimentScore.Negative');
+  const score = positive - negative;
+  return score;
+}
+
+
+async function sendForProcessing(sentimentRequest: SentimentRequest) {
+  clearTimeoutToken();
+  batchBuffer.push(sentimentRequest);
+  if (timeoutToken === undefined) {
+    timeoutToken = setTimeout(() => {
+      dispatch();
+    }, WAIT_MS_BEFORE_SENDING);
+  }
+}
+
+export default { analyzeText };

--- a/src/services/sentiment-analyzer.service.ts
+++ b/src/services/sentiment-analyzer.service.ts
@@ -15,7 +15,7 @@ const WAIT_MS_BEFORE_SENDING = 1000;
 const MAX_BATCH_BUFFER_SIZE = 25;
 const COMPREHEND_QUOTA_PER_SECOND = 10;
 
-export async function analyzeText(text: string): Promise<number> {
+async function analyzeText(text: string): Promise<number> {
   // logger.debug('Analysing text');
   return new Promise((res, rej) => {
     sendForProcessing({

--- a/src/utils/loadNewsServicesToAnalyze.ts
+++ b/src/utils/loadNewsServicesToAnalyze.ts
@@ -1,0 +1,31 @@
+import { Observable } from "rxjs";
+import { config } from '../config'
+import { NewsService } from "../services/news";
+import { NewsApiSource, NewsApiService, craftNewsServiceFromNewsApiSource } from "../services/news/newsapi.service";
+import { logger } from "./logger.util";
+
+/**
+ * most important function that people can contribute to.
+ * this is the entry point of the function; it prepares the NewsServices, which are then piped
+ * into retrieveScoreFromNewsService(). see handler().
+ */
+function loadNewsServicesToAnalyze(): Observable<NewsService> {
+  return new Observable(subscriber => {
+    Promise.all([
+      (async () => {
+        // loads NewsServices from NewsAPI.org
+        let sources: Array<NewsApiSource> = await NewsApiService.getSources();
+        let sourcesToLookFor = sources.filter(source => source.language === 'en');
+        if (config.isDev) {
+          let sourceLimit = 3;
+          logger.info(`Limiting source to ${sourceLimit} sources.`);
+          sourcesToLookFor = sourcesToLookFor.slice(0, sourceLimit);
+        }
+        sourcesToLookFor.forEach(source => subscriber.next(craftNewsServiceFromNewsApiSource(source)));
+      })(),
+    ]).then(() => subscriber.complete())
+      .catch(e => subscriber.error(e));
+  });
+}
+
+export default loadNewsServicesToAnalyze;

--- a/src/utils/logger.util.ts
+++ b/src/utils/logger.util.ts
@@ -4,6 +4,13 @@ import { config } from '../config';
 
 // TODO load from env
 const LOG_LEVEL: log.LogLevelDesc = config.logLevel as log.LogLevelDesc;
+const originalFactory = log.methodFactory;
+log.methodFactory = (methodName, logLevel, loggerName) => {
+  if (methodName === 'debug' && logLevel <= log.levels.DEBUG) {
+    return console.debug;
+  }
+  return originalFactory(methodName, logLevel, loggerName);
+};
 log.setDefaultLevel(LOG_LEVEL);
 
 export const logger = log;

--- a/src/utils/mockAsync.ts
+++ b/src/utils/mockAsync.ts
@@ -1,0 +1,3 @@
+export default async function<T>(val: T, ms: number = 1000): Promise<T> {
+  return new Promise(res => setTimeout(() => res(val), ms));
+}

--- a/src/utils/setupTest.ts
+++ b/src/utils/setupTest.ts
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,6 @@ Resources:
             CodeUri: dist/
             Handler: lambda-handlers/get-news.getNews
             Runtime: nodejs12.x
-            Timeout: 30
             Events:
                 GetNewsSourcesApi:
                     Type: Api

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,5 +66,8 @@
   },
   "include": [
     "src"
-  ]
+  ],
+  "exclude": [
+    "./**/*.spec.ts"
+  ],
 }


### PR DESCRIPTION
Closes #4 

This PR is for the switch to AWS Comprehend for sentiment analysis of various kinds of text (exposed by the simple analyzeText method in sentiment-analyzer.service; the API surface hasn't changed yet, except that it's exposed through a default export instead of a direct export).

Also adds internal rate-limiting to sentiment-analyzer.service so that AWS doesn't ban me.

Added tests too, finally!